### PR TITLE
Update README.adoc to clean up containers after launch

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -525,4 +525,4 @@ You should be able to execute `audiowmark` via Docker.
 Example that outputs the usage message:
 
   docker build -t audiowmark .
-  docker run -v <local-data-directory>:/data -it audiowmark -h
+  docker run -v <local-data-directory>:/data --rm -it audiowmark -h


### PR DESCRIPTION
In line with https://docs.docker.com/engine/reference/run/#clean-up---rm to avoid having hanging containers after working with the tool via docker.