### PR TITLE
Add options for changing parameters

### DIFF
--- a/src/audiowmark.cc
+++ b/src/audiowmark.cc
@@ -583,6 +583,10 @@ parse_shared_options (ArgParser& ap)
     {
       Params::payload_size = i;
     }
+  if (ap.parse_opt ("--threshold", f))
+    {
+      Params::sync_threshold2 = f;
+    }
 }
 
 void

--- a/src/audiowmark.cc
+++ b/src/audiowmark.cc
@@ -575,6 +575,10 @@ parse_shared_options (ArgParser& ap)
       error ("audiowmark: watermark key can at most be set once (--key / --test-key option)\n");
       exit (1);
     }
+  if (ap.parse_opt ("--frame-size", i))
+    {
+      Params::frame_size = i;
+    }
 }
 
 void

--- a/src/audiowmark.cc
+++ b/src/audiowmark.cc
@@ -579,6 +579,10 @@ parse_shared_options (ArgParser& ap)
     {
       Params::frame_size = i;
     }
+  if (ap.parse_opt ("--payload-size", i))
+    {
+      Params::payload_size = i;
+    }
 }
 
 void

--- a/src/wmcommon.cc
+++ b/src/wmcommon.cc
@@ -25,6 +25,7 @@ using std::vector;
 using std::complex;
 
 size_t Params::frame_size      = 1024;
+double Params::sync_threshold2 = 0.7;
 int    Params::frames_per_bit  = 2;
 double Params::water_delta     = 0.01;
 bool   Params::mix             = true;

--- a/src/wmcommon.cc
+++ b/src/wmcommon.cc
@@ -24,6 +24,7 @@ using std::string;
 using std::vector;
 using std::complex;
 
+size_t Params::frame_size      = 1024;
 int    Params::frames_per_bit  = 2;
 double Params::water_delta     = 0.01;
 bool   Params::mix             = true;

--- a/src/wmcommon.hh
+++ b/src/wmcommon.hh
@@ -59,7 +59,7 @@ public:
   static constexpr int sync_frames_per_bit = 85;
   static constexpr int sync_search_step    = 256;
   static constexpr int sync_search_fine    = 8;
-  static constexpr double sync_threshold2  = 0.7; // minimum refined quality
+  static           double sync_threshold2;
 
   static constexpr size_t frames_pad_start = 250; // padding at start, in case track starts with silence
   static constexpr int mark_sample_rate = 44100; // watermark generation and detection sample rate

--- a/src/wmcommon.hh
+++ b/src/wmcommon.hh
@@ -33,7 +33,7 @@ enum class Format { AUTO = 1, RAW = 2, RF64 = 3 };
 class Params
 {
 public:
-  static constexpr size_t frame_size      = 1024;
+  static           size_t frame_size;
   static           int    frames_per_bit;
   static constexpr size_t bands_per_frame = 30;
   static constexpr int max_band          = 100;


### PR DESCRIPTION
I came across your open source while searching for audio watermarking techniques. I thought your audiowmark was the most well-crafted code among the technologies that are currently being released as open source. So I studied the code, and I thought about under what circumstances the watermark can remain robust. What I found was payload_size and frame_size. I thought that if the number of watermarks increases when payload_size and frame_size are moderately small, it is more robust. And sometimes, when the threshold to find the watermark was adjusted as needed, there were cases where the watermark that was not extracted was well extracted. So I added 3 options.

--frame-size "int"
--payload-size "int"
--threshold "float"

Through the above 3 options, each parameter can be made smaller or larger.
