### PR TITLE
Fix build for compilers which need __STDC_FORMAT_MACROS

### DIFF
--- a/src/hls.cc
+++ b/src/hls.cc
@@ -23,6 +23,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
+
 #include "utils.hh"
 #include "mpegts.hh"
 #include "sfinputstream.hh"

--- a/src/hlsoutputstream.cc
+++ b/src/hlsoutputstream.cc
@@ -15,6 +15,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
+
 #include "hlsoutputstream.hh"
 
 #undef av_err2str

--- a/src/testhls.cc
+++ b/src/testhls.cc
@@ -20,6 +20,11 @@
 
 #include <regex>
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
+
 #include "utils.hh"
 #include "mpegts.hh"
 #include "wavdata.hh"

--- a/src/testrandom.cc
+++ b/src/testrandom.cc
@@ -18,7 +18,10 @@
 #include "utils.hh"
 #include "random.hh"
 
-#include <inttypes.h>
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <cinttypes>
 
 using std::vector;
 using std::string;


### PR DESCRIPTION
This is necessary for some platforms/compilers. Should be inconsequential for others.