### PR TITLE
Preserve WAV subformat

### DIFF
--- a/src/sfinputstream.cc
+++ b/src/sfinputstream.cc
@@ -16,6 +16,7 @@
  */
 
 #include "sfinputstream.hh"
+#include "wmcommon.hh"
 
 #include <assert.h>
 #include <string.h>
@@ -71,6 +72,9 @@ SFInputStream::open (std::function<SNDFILE* (SF_INFO *)> open_func)
   m_n_channels  = sfinfo.channels;
   m_n_frames    = (sfinfo.frames == SF_COUNT_MAX) ? N_FRAMES_UNKNOWN : sfinfo.frames;
   m_sample_rate = sfinfo.samplerate;
+
+  if (!Params::input_sndfile_flags)
+    Params::input_sndfile_flags = sfinfo.format; // saved for output_format detection
 
   switch (sfinfo.format & SF_FORMAT_SUBMASK)
     {

--- a/src/sfoutputstream.hh
+++ b/src/sfoutputstream.hh
@@ -37,6 +37,7 @@ private:
   int         m_bit_depth = 0;
   int         m_sample_rate = 0;
   int         m_n_channels = 0;
+  bool        m_write_float_data = false;
 
   enum class State {
     NEW,

--- a/src/wmcommon.cc
+++ b/src/wmcommon.cc
@@ -42,6 +42,7 @@ bool   Params::test_no_limiter = false; // disable limiter
 int    Params::test_truncate   = 0;
 int    Params::expect_matches  = -1;
 
+uint64_t Params::input_sndfile_flags = 0;
 Format Params::input_format     = Format::AUTO;
 Format Params::output_format    = Format::AUTO;
 

--- a/src/wmcommon.hh
+++ b/src/wmcommon.hh
@@ -72,6 +72,7 @@ public:
   static           int test_truncate;
   static           int expect_matches;
 
+  static           uint64_t input_sndfile_flags;
   static           Format input_format;
   static           Format output_format;
 


### PR DESCRIPTION
Some users expect 32 bit PCM WAV files, Float32 WAV files and FLoat64 WAV files to be created by Audiowmark if that was the input format.

This PR preserves the WAV subformat information from the input WAV file and will re-apply that when the output WAV file is written with AUTO format detection - the default case, unless the --output-format option was provided.
So the code will now write WAV files in the format the input file was read with, for formats > 24 bit, that improves the output quality. But 8 bit WAV files are now written in 8 bit, instead of the 16 bit that Audiowmark used formerly.

The watermarks are still detected well though, here are some examples:  

Input File     : 'wm-pcmu8.wav'
Precision      : 8-bit
Sample Encoding: 8-bit Unsigned Integer PCM
pattern   all 00ff00ff00ff00ff00ff00ff00ff00ff 1.487 0.060

Input File     : 'wm-pcm16.wav'
Precision      : 16-bit
Sample Encoding: 16-bit Signed Integer PCM
pattern   all 00ff00ff00ff00ff00ff00ff00ff00ff 1.415 0.065

Input File     : 'wm-pcm24.wav'
Precision      : 24-bit
Sample Encoding: 24-bit Signed Integer PCM
pattern   all 00ff00ff00ff00ff00ff00ff00ff00ff 1.415 0.065

Input File     : 'wm-pcm32.wav'
Precision      : 32-bit
Sample Encoding: 32-bit Signed Integer PCM
pattern   all 00ff00ff00ff00ff00ff00ff00ff00ff 1.415 0.065

Input File     : 'wm-float32.wav'
Precision      : 25-bit
Sample Encoding: 32-bit Floating Point PCM
pattern   all 00ff00ff00ff00ff00ff00ff00ff00ff 1.415 0.065

Input File     : 'wm-float64.wav'
Precision      : 54-bit
Sample Encoding: 64-bit Floating Point PCM
pattern   all 00ff00ff00ff00ff00ff00ff00ff00ff 1.415 0.065

Note that the above "Precision" is as reported by SOXI, the watermark is correctly detected in all cases.
