### PR TITLE
src/hlsoutputstream.*: migrate to use AVChannelLayout

### DIFF
--- a/src/hlsoutputstream.hh
+++ b/src/hlsoutputstream.hh
@@ -76,7 +76,7 @@ class HLSOutputStream : public AudioOutputStream {
   };
   EncResult write_audio_frame (Error& err);
   void close_stream();
-  AVFrame *alloc_audio_frame (AVSampleFormat sample_fmt, uint64_t channel_layout, int sample_rate, int nb_samples, Error& err);
+  AVFrame *alloc_audio_frame (AVSampleFormat sample_fmt, const AVChannelLayout *channel_layout, int sample_rate, int nb_samples, Error& err);
 
   int write_frame (const AVRational *time_base, AVStream *st, AVPacket *pkt);
 public:


### PR DESCRIPTION
Fixes #62: https://github.com/swesterfeld/audiowmark/issues/62

Starting ffmpeg-7, the old av_get_channel_layout() API is gone and use of AVChannelLayout is mandatory.


This PR fixes build failures on Arch by porting audiowmark to the ffmpeg-7 API.