### PR TITLE
docs: fix separated spelling in README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -99,7 +99,7 @@ To get the 128-bit message from the watermarked file, use:
 ....
 The output of `audiowmark get` is designed to be machine readable. Each line
 that starts with `pattern` contains one decoded message. The fields are
-seperated by one or more space characters. The first field is a *timestamp*
+separated by one or more space characters. The first field is a *timestamp*
 indicating the position of the data block. The second field is the *decoded
 message*. The results are sorted by relevance, the most relevant matches
 are shown first.


### PR DESCRIPTION
Changes:
- `seperated` -> `separated` in `README.adoc` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked my prior PRs in this repository before opening this PR.
